### PR TITLE
Fix missing mobile navigation links for services and products

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -158,6 +158,18 @@ const showingNavigationDropdown = ref(false);
                         >
                             Dashboard
                         </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            :href="route('services.index')"
+                            :active="route().current('services.index')"
+                        >
+                            Services
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            :href="route('products.index')"
+                            :active="route().current('products.index')"
+                        >
+                            Products
+                        </ResponsiveNavLink>
                     </div>
 
                     <!-- Responsive Settings Options -->


### PR DESCRIPTION
## Summary
- add Services and Products links to mobile navigation menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4dd2f708320b1ca931b4c6c6b26