### PR TITLE
Add partner management with image upload

### DIFF
--- a/app/Http/Controllers/PartnerController.php
+++ b/app/Http/Controllers/PartnerController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Partner;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PartnerController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Partners/Index', [
+            'partners' => Partner::orderBy('sort_order')->get(),
+        ]);
+    }
+
+    public function publicIndex(): Response
+    {
+        return Inertia::render('Public/Partners/Index', [
+            'partners' => Partner::orderBy('sort_order')->get(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Partners/Create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'image' => ['required', 'image', 'mimes:jpg,jpeg,png', 'dimensions:width=600,height=600'],
+            'alt_text' => ['nullable', 'string', 'max:255'],
+            'sort_order' => ['nullable', 'integer'],
+        ]);
+
+        $path = $request->file('image')->store('partners', 'public');
+
+        Partner::create([
+            'image_path' => $path,
+            'alt_text' => $validated['alt_text'] ?? null,
+            'sort_order' => $validated['sort_order'] ?? 0,
+        ]);
+
+        return redirect()->route('partners.index');
+    }
+
+    public function edit(Partner $partner): Response
+    {
+        return Inertia::render('Partners/Edit', [
+            'partner' => $partner,
+        ]);
+    }
+
+    public function update(Request $request, Partner $partner)
+    {
+        $validated = $request->validate([
+            'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png', 'dimensions:width=600,height=600'],
+            'alt_text' => ['nullable', 'string', 'max:255'],
+            'sort_order' => ['nullable', 'integer'],
+        ]);
+
+        $data = [
+            'alt_text' => $validated['alt_text'] ?? null,
+            'sort_order' => $validated['sort_order'] ?? 0,
+        ];
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('partners', 'public');
+        }
+
+        $partner->update($data);
+
+        return redirect()->route('partners.index');
+    }
+
+    public function destroy(Partner $partner)
+    {
+        $partner->delete();
+
+        return redirect()->route('partners.index');
+    }
+}

--- a/app/Models/Partner.php
+++ b/app/Models/Partner.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Partner extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'image_path',
+        'alt_text',
+        'sort_order',
+    ];
+}

--- a/database/migrations/2025_08_07_000005_create_partners_table.php
+++ b/database/migrations/2025_08_07_000005_create_partners_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('partners', function (Blueprint $table) {
+            $table->id();
+            $table->string('image_path');
+            $table->string('alt_text')->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('partners');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\PartnerSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -32,5 +33,7 @@ class DatabaseSeeder extends Seeder
                 'role' => 'super_admin',
             ]
         );
+
+        $this->call(PartnerSeeder::class);
     }
 }

--- a/database/seeders/PartnerSeeder.php
+++ b/database/seeders/PartnerSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Partner;
+use Illuminate\Database\Seeder;
+
+class PartnerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Partner::create([
+            'image_path' => 'partners/sample.png',
+            'alt_text' => 'Sample Partner',
+            'sort_order' => 1,
+        ]);
+    }
+}

--- a/resources/js/Pages/Partners/Create.vue
+++ b/resources/js/Pages/Partners/Create.vue
@@ -1,0 +1,57 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const form = useForm({
+    image: null,
+    alt_text: '',
+    sort_order: 0,
+});
+
+function submit() {
+    form.post('/admin/partners', { forceFormData: true });
+}
+</script>
+
+<template>
+    <Head title="Create Partner" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Create Partner
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <form @submit.prevent="submit" class="bg-white shadow sm:rounded-lg p-6 space-y-6" enctype="multipart/form-data">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Image</label>
+                        <input type="file" @change="form.image = $event.target.files[0]" class="mt-1 block w-full" />
+                        <p class="text-xs text-gray-500 mt-1">Image should be 600x600 px.</p>
+                        <span v-if="form.errors.image" class="text-red-500 text-xs">{{ form.errors.image }}</span>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Alt Text</label>
+                        <input v-model="form.alt_text" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                        <span v-if="form.errors.alt_text" class="text-red-500 text-xs">{{ form.errors.alt_text }}</span>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Order</label>
+                        <input v-model="form.sort_order" type="number" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                        <span v-if="form.errors.sort_order" class="text-red-500 text-xs">{{ form.errors.sort_order }}</span>
+                    </div>
+
+                    <div class="flex justify-end">
+                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Partners/Edit.vue
+++ b/resources/js/Pages/Partners/Edit.vue
@@ -1,0 +1,65 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const props = defineProps({
+    partner: {
+        type: Object,
+        required: true,
+    },
+});
+
+const form = useForm({
+    image: null,
+    alt_text: props.partner.alt_text || '',
+    sort_order: props.partner.sort_order || 0,
+});
+
+function submit() {
+    form.post(`/admin/partners/${props.partner.id}`, { forceFormData: true, _method: 'put' });
+}
+</script>
+
+<template>
+    <Head title="Edit Partner" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Edit Partner
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <form @submit.prevent="submit" class="bg-white shadow sm:rounded-lg p-6 space-y-6" enctype="multipart/form-data">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Current Image</label>
+                        <img :src="`/storage/${props.partner.image_path}`" :alt="props.partner.alt_text" class="h-16 w-16 object-cover mb-2" />
+                        <input type="file" @change="form.image = $event.target.files[0]" class="mt-1 block w-full" />
+                        <p class="text-xs text-gray-500 mt-1">Image should be 600x600 px.</p>
+                        <span v-if="form.errors.image" class="text-red-500 text-xs">{{ form.errors.image }}</span>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Alt Text</label>
+                        <input v-model="form.alt_text" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                        <span v-if="form.errors.alt_text" class="text-red-500 text-xs">{{ form.errors.alt_text }}</span>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Order</label>
+                        <input v-model="form.sort_order" type="number" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                        <span v-if="form.errors.sort_order" class="text-red-500 text-xs">{{ form.errors.sort_order }}</span>
+                    </div>
+
+                    <div class="flex justify-end">
+                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">
+                            Update
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Partners/Index.vue
+++ b/resources/js/Pages/Partners/Index.vue
@@ -1,0 +1,76 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+defineProps({
+    partners: {
+        type: Array,
+        default: () => [],
+    },
+});
+</script>
+
+<template>
+    <Head title="Partners" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">Partners</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="flex justify-end mb-4">
+                    <Link
+                        href="/admin/partners/create"
+                        class="px-4 py-2 bg-blue-600 text-white rounded"
+                    >
+                        New Partner
+                    </Link>
+                </div>
+
+                <div class="bg-white shadow-sm sm:rounded-lg">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Image
+                                </th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Alt Text
+                                </th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Order
+                                </th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Actions
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr v-for="partner in partners" :key="partner.id">
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <img :src="`/storage/${partner.image_path}`" :alt="partner.alt_text" class="h-16 w-16 object-cover" />
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    {{ partner.alt_text }}
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    {{ partner.sort_order }}
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap space-x-2">
+                                    <Link
+                                        :href="`/admin/partners/${partner.id}/edit`"
+                                        class="text-indigo-600 hover:text-indigo-900"
+                                    >
+                                        Edit
+                                    </Link>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Public/Partners/Index.vue
+++ b/resources/js/Pages/Public/Partners/Index.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { Head } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+defineProps({
+    partners: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+defineOptions({ layout: AppLayout });
+</script>
+
+<template>
+    <Head title="Partners" />
+
+    <div class="min-h-screen bg-gray-100 py-12">
+        <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            <h1 class="text-2xl font-bold mb-6">Our Partners</h1>
+
+            <div class="grid gap-6 md:grid-cols-3 lg:grid-cols-4">
+                <div
+                    v-for="partner in partners"
+                    :key="partner.id"
+                    class="bg-white overflow-hidden shadow-sm rounded-lg p-6 flex items-center justify-center"
+                >
+                    <img :src="`/storage/${partner.image_path}`" :alt="partner.alt_text" class="h-24 w-24 object-cover" />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ServiceController;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\PartnerController;
 use App\Models\Product;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -19,9 +20,10 @@ Route::get('/', function () {
     ]);
 });
 
-// Public product & service listings
+// Public product, service & partner listings
 Route::get('/products', [ProductController::class, 'publicIndex'])->name('products.public.index');
 Route::get('/services', [ServiceController::class, 'publicIndex'])->name('services.public.index');
+Route::get('/partners', [PartnerController::class, 'publicIndex'])->name('partners.public.index');
 
 Route::get('/admin/dashboard', function () {
     return Inertia::render('Dashboard');
@@ -38,6 +40,7 @@ Route::middleware(['auth', 'verified', \App\Http\Middleware\EnsureAdmin::class])
     ->group(function () {
         Route::resource('services', ServiceController::class);
         Route::resource('products', ProductController::class);
+        Route::resource('partners', PartnerController::class);
     });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add partners table with image path, alt text and sortable order
- build partner CRUD UI with 600x600 image upload
- expose partner listings publicly and under admin area

## Testing
- `composer install` *(fails: Failed to download doctrine/lexer from dist: curl error 56... CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js"*)


------
https://chatgpt.com/codex/tasks/task_e_68a16d1fdec48320860639d23426143d