### PR TITLE
Add localized routing and dynamic translations

### DIFF
--- a/app/Http/Controllers/PartnerController.php
+++ b/app/Http/Controllers/PartnerController.php
@@ -16,10 +16,11 @@ class PartnerController extends Controller
         ]);
     }
 
-    public function publicIndex(): Response
+    public function publicIndex(string $lang): Response
     {
         return Inertia::render('Public/Partners/Index', [
             'partners' => Partner::orderBy('sort_order')->get(),
+            'lang' => $lang,
         ]);
     }
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -20,12 +20,13 @@ class ProductController extends Controller
     /**
      * Display a public listing of the products.
      */
-    public function publicIndex(): Response
+    public function publicIndex(string $lang): Response
     {
         return Inertia::render('Public/Products/Index', [
             'products' => Product::all(),
             'menu_style' => 'white',
             'footer_style' => 'dark',
+            'lang' => $lang,
         ]);
     }
 

--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -20,11 +20,12 @@ class ServiceController extends Controller
     /**
      * Display a public listing of the services.
      */
-    public function publicIndex(): Response
+    public function publicIndex(string $lang): Response
     {
         return Inertia::render('Public/Services/Index', [
             'menu_style' => 'black',
             'footer_style' => 'light',
+            'lang' => $lang,
         ]);
     }
 

--- a/resources/js/Components/TheFooter.vue
+++ b/resources/js/Components/TheFooter.vue
@@ -13,12 +13,9 @@
         </div>
         <div class="col-span-1 flex flex-col justify-start md:justify-end gap-6 items-center md:items-start">
           <div class="flex flex-col gap-6 md:gap-2">
-            <h3 class="text-4xl font-white leading-9">
-              Ready to explore new opportunities together?<br>
-              Get in touch with us.
-            </h3>
-            <Link 
-              href="/contact" 
+            <h3 class="text-4xl font-white leading-9" v-html="footerTexts.get_in_touch_text"></h3>
+            <Link
+              :href="localizedPath('contact')"
               class="w-fit mt-6 md:mt-20 mb-6 md:mb-28  px-6 py-3  hover:font-bold transition-colors"
               :class="{
                 'bg-box-yellow-light hover:bg-box-yellow-light/90 text-box-brown': page.props.footer_style === 'dark',
@@ -26,7 +23,7 @@
               }"
               type="button"
             >
-              Contact Us
+              {{ footerTexts.contact_us_button }}
             </Link>
             <p class="text-xs">
               Box Industries © 2025. Todos Los Derechos Reservados.<br>
@@ -38,7 +35,7 @@
         <div class="col-span-1 flex flex-col justify-between gap-6">
           <div class="w-full mt-2 flex flex-col md:flex-row items-stretch justify-between">
             <div>
-              <p class="text-base hidden md:block">Follow Us</p>
+              <p class="text-base hidden md:block">{{ footerTexts.follow_us }}</p>
             </div>
             <div class="flex items-center justify-center gap-2">
               <a href="https://www.facebook.com/BoxIndustriesMX/" target="_blank">
@@ -70,6 +67,8 @@ import Instagram from './Images/Logos.vue/Instagram.vue';
 import LinkedIn from './Images/Logos.vue/LinkedIn.vue';
 import { Link } from '@inertiajs/vue3';
 import { usePage } from '@inertiajs/vue3';
+import { useTexts } from '@/composables/useTexts';
+import { useLocale } from '@/composables/useLocale';
 
 defineProps({
   mode: {
@@ -79,5 +78,7 @@ defineProps({
 });
 
 const page = usePage();
+const { texts: footerTexts } = useTexts('footer');
+const { localizedPath } = useLocale();
 
 </script>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -1,21 +1,38 @@
 <script setup>
 import { Link, usePage, router } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import WoodLogo from '@/Components/Images/WoodLogo.vue';
 import WhiteLogo from '@/Components/Images/WhiteLogo.vue';
 import BlackLogo from '@/Components/Images/BlackLogo.vue';
 import TheFooter from '@/Components/TheFooter.vue';
+import { useTexts } from '@/composables/useTexts';
+import { useLocale } from '@/composables/useLocale';
 
 const isOpen = ref(false);
 
 const page = usePage();
+const { texts: menuTexts } = useTexts('menu');
+const { lang, localizedPath, pathForLanguage } = useLocale();
+
+const otherLang = computed(() => (lang.value === 'en' ? 'es' : 'en'));
+const languageLabels: Record<string, string> = {
+  en: 'English',
+  es: 'Español',
+};
+
+const switchLanguageHref = computed(() => pathForLanguage(otherLang.value as 'en' | 'es'));
 
 function logoClick() {
   if (!isOpen.value) {
-    router.visit('/')
+    router.visit(localizedPath());
   } else {
     isOpen.value = !isOpen.value;
   }
+}
+
+function navigate(path: string) {
+  router.visit(localizedPath(path));
+  isOpen.value = false;
 }
 
 </script>
@@ -52,20 +69,23 @@ function logoClick() {
         <div
           class="flex items-center text-sm bg-white/10 lg:text-base backdrop-blur font-medium"
         >
-          <Link 
-            href="/products" 
+          <Link
+            :href="localizedPath('products')"
             class="hover:text-yellow-400 p-3"
             @click="isOpen = false"
-          >Products</Link>
-          <Link href="/services" class="hover:text-yellow-400 p-3" @click="isOpen = false">Expertise</Link>
-          <Link href="/company" class="hover:text-yellow-400 p-3" @click="isOpen = false">Company</Link>
-          <Link href="/environment" class="hover:text-yellow-400 p-3" @click="isOpen = false">Environment</Link>
-          <Link href="/contact" class="hover:text-yellow-400 p-3" @click="isOpen = false">Contact</Link>
+          >{{ menuTexts.products }}</Link>
+          <Link :href="localizedPath('services')" class="hover:text-yellow-400 p-3" @click="isOpen = false">{{ menuTexts.services }}</Link>
+          <Link :href="localizedPath('company')" class="hover:text-yellow-400 p-3" @click="isOpen = false">{{ menuTexts.company }}</Link>
+          <Link :href="localizedPath('environment')" class="hover:text-yellow-400 p-3" @click="isOpen = false">{{ menuTexts.environment }}</Link>
+          <Link :href="localizedPath('contact')" class="hover:text-yellow-400 p-3" @click="isOpen = false">{{ menuTexts.contact }}</Link>
         </div>
 
         <div class="flex items-center text-sm bg-white/10 lg:text-base backdrop-blur font-medium">
-          <Link href="#" class="hover:text-yellow-400 p-3" @click="isOpen = false">Eng</Link>
-          <Link href="#" class="hover:text-yellow-400 p-3" @click="isOpen = false">Spa</Link>
+          <Link
+            :href="switchLanguageHref"
+            class="hover:text-yellow-400 p-3"
+            @click="isOpen = false"
+          >{{ languageLabels[otherLang] }}</Link>
         </div>
       </div>
 
@@ -84,11 +104,16 @@ function logoClick() {
           v-if="isOpen"
           class="md:hidden absolute inset-x-0 top-0 backdrop-blur py-8 px-10 flex flex-col items-end space-y-6 z-40"
         >
-          <Link href="/products" class="text-lg hover:text-yellow-400" @click="isOpen = false">Products</Link>
-          <Link href="/services" class="text-lg hover:text-yellow-400" @click="isOpen = false">Expertise</Link>
-          <Link href="/company" class="text-lg hover:text-yellow-400" @click="isOpen = false">Company</Link>
-          <Link href="/environment" class="text-lg hover:text-yellow-400" @click="isOpen = false">Environment</Link>
-          <Link href="/contact" class="text-lg hover:text-yellow-400" @click="isOpen = false">Contact</Link>
+          <button type="button" class="text-lg hover:text-yellow-400" @click="navigate('products')">{{ menuTexts.products }}</button>
+          <button type="button" class="text-lg hover:text-yellow-400" @click="navigate('services')">{{ menuTexts.services }}</button>
+          <button type="button" class="text-lg hover:text-yellow-400" @click="navigate('company')">{{ menuTexts.company }}</button>
+          <button type="button" class="text-lg hover:text-yellow-400" @click="navigate('environment')">{{ menuTexts.environment }}</button>
+          <button type="button" class="text-lg hover:text-yellow-400" @click="navigate('contact')">{{ menuTexts.contact }}</button>
+          <Link
+            :href="switchLanguageHref"
+            class="text-lg hover:text-yellow-400"
+            @click="isOpen = false"
+          >{{ languageLabels[otherLang] }}</Link>
         </div>
       </transition>
 

--- a/resources/js/Pages/Company/Hero_Figma.vue
+++ b/resources/js/Pages/Company/Hero_Figma.vue
@@ -7,9 +7,7 @@
     >
 
       <h1 class="mt-4 text-black font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl mb-10">
-        The Packaging 
-        <br class="hidden sm:block" />
-        Solutions Company
+        {{ companyTexts.hero_large }}
       </h1>
       <div class="w-full h-auto">
         <img
@@ -19,12 +17,7 @@
         />
       </div>
       <div class="w-full my-10 text-black text-2xl md:text-3xl font-light">
-        <p>
-          Box Industries was founded in 2008 in Arteaga, Coahuila. Since then, we've 
-          specialized in designing and manufacturing custom packaging solutions — 
-          from corrugated boxes to returnable plastic systems — tailored to the 
-          needs of today's industries.
-        </p>
+        <p>{{ companyTexts.hero_small }}</p>
       </div>
 
     </div>
@@ -35,7 +28,9 @@
 </template>
 
 <script setup>
-import { Link } from '@inertiajs/vue3';
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: companyTexts } = useTexts('company');
 
 </script>

--- a/resources/js/Pages/Company/InNumbers.vue
+++ b/resources/js/Pages/Company/InNumbers.vue
@@ -4,21 +4,28 @@
       <div class="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
         <div class="space-y-2">
           <h3 class="text-4xl md:text-5xl font-bold text-gray-900">42+</h3>
-          <p class="text-gray-600 font-medium">Employees</p>
+          <p class="text-gray-600 font-medium">{{ companyTexts.numbers_employees }}</p>
         </div>
         <div class="space-y-2">
           <h3 class="text-4xl md:text-5xl font-bold text-gray-900">500+</h3>
-          <p class="text-gray-600 font-medium">Trusted Clients</p>
+          <p class="text-gray-600 font-medium">{{ companyTexts.numbers_clients }}</p>
         </div>
         <div class="space-y-2">
           <h3 class="text-4xl md:text-5xl font-bold text-gray-900">5.5M+</h3>
-          <p class="text-gray-600 font-medium">Packaging Developed</p>
+          <p class="text-gray-600 font-medium">{{ companyTexts.numbers_tonnes }}</p>
         </div>
         <div class="space-y-2">
           <h3 class="text-4xl md:text-5xl font-bold text-gray-900">2008</h3>
-          <p class="text-gray-600 font-medium">Established</p>
+          <p class="text-gray-600 font-medium">{{ companyTexts.numbers_established }}</p>
         </div>
       </div>
     </div>
   </section>
 </template>
+
+<script setup>
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: companyTexts } = useTexts('company');
+
+</script>

--- a/resources/js/Pages/Company/Index.vue
+++ b/resources/js/Pages/Company/Index.vue
@@ -5,13 +5,16 @@ import InNumbers from '@/Pages/Company/InNumbers.vue';
 import WhatWeStandFor from '@/Pages/Company/WhatWeStandFor.vue';
 import Partners from '@/Components/Containers/Partners.vue';
 import { Head } from '@inertiajs/vue3';
+import { useTexts } from '@/composables/useTexts';
 
 defineOptions({ layout: AppLayout });
+
+const { texts: companyTexts } = useTexts('company');
 
 </script>
 
 <template>
-  <Head title="Company" />
+  <Head :title="companyTexts.title || 'Company'" />
     <!-- Hero Section -->
     <Hero />
     <!-- Statistics Section -->
@@ -21,16 +24,7 @@ defineOptions({ layout: AppLayout });
     <!-- Partners Section -->
     <section class="text-black bg-gray-100 py-16 font-bold">
       <div class="w-full max-w-7xl mx-auto px-6 text-2xl">
-        <p class="leading-relaxed">
-          With over a decade of experience, Box Industries designs and manufactures 
-          strategic, high-performance packaging solutions. We optimize every detail 
-          — from raw materials to logistics — to deliver agile, scalable, and cost-efficient 
-          results.
-        </p>
-        <p class="leading-relaxed mt-4">
-          Trusted by leading global industries, including long-term partnerships in many 
-          sectors.
-        </p>
+        <p class="leading-relaxed">{{ companyTexts.our_experience }}</p>
       </div>
       <Partners class="w-full max-w-7xl mx-auto" />
     </section>

--- a/resources/js/Pages/Company/WhatWeStandFor.vue
+++ b/resources/js/Pages/Company/WhatWeStandFor.vue
@@ -2,7 +2,7 @@
   <section class="bg-gray-100">
     <div class="max-w-7xl mx-auto px-6">
       <h2 class="text-4xl md:text-5xl font-bold text-gray-900 mb-16">
-        What we stand for
+        {{ companyTexts.what_we_do_title }}
       </h2>
 
       <div class="space-y-16">
@@ -16,11 +16,9 @@
             />
           </div>
           <div>
-            <h3 class="text-3xl font-bold text-gray-900 mb-6">We analyze</h3>
+            <h3 class="text-3xl font-bold text-gray-900 mb-6">{{ companyTexts.we_analyze_title }}</h3>
             <p class="text-lg text-gray-700 leading-relaxed">
-              Each packaging challenge is an opportunity to create value. 
-              We apply our expertise in delivering efficient logistics 
-              and strategic design solutions.
+              {{ companyTexts.we_analyze_description }}
             </p>
           </div>
         </div>
@@ -35,12 +33,9 @@
             />
           </div>
           <div>
-            <h3 class="text-3xl font-bold text-gray-900 mb-6">We adapt</h3>
+            <h3 class="text-3xl font-bold text-gray-900 mb-6">{{ companyTexts.we_adapt_title }}</h3>
             <p class="text-lg text-gray-700 leading-relaxed">
-              Speed and flexibility are part of our DNA. We enable 
-              our client's success by designing custom-made efficient systems 
-              that operate seamlessly across various logistics and supply 
-              chains.
+              {{ companyTexts.we_adapt_description }}
             </p>
           </div>
         </div>
@@ -55,12 +50,9 @@
             />
           </div>
           <div>
-            <h3 class="text-3xl font-bold text-gray-900 mb-6">We collaborate</h3>
+            <h3 class="text-3xl font-bold text-gray-900 mb-6">{{ companyTexts.we_collaborate_title }}</h3>
             <p class="text-lg text-gray-700 leading-relaxed">
-              Our core skill lies in teamwork — both within our 
-              experienced team and with our clients. We believe in integrating 
-              diverse perspectives to work cooperatively towards achieving 
-              shared goals.
+              {{ companyTexts.we_collaborate_description }}
             </p>
           </div>
         </div>
@@ -75,12 +67,9 @@
             />
           </div>
           <div>
-            <h3 class="text-3xl font-bold text-gray-900 mb-6">We care</h3>
+            <h3 class="text-3xl font-bold text-gray-900 mb-6">{{ companyTexts.we_care_title }}</h3>
             <p class="text-lg text-gray-700 leading-relaxed">
-              From materials to logistics, we care about every step in 
-              our process. Our dedicated teams ensure that nothing leaves 
-              our manufacturing facilities without exceeding — without 
-              compromising performance.
+              {{ companyTexts.we_care_description }}
             </p>
           </div>
         </div>
@@ -88,3 +77,10 @@
     </div>
   </section>
 </template>
+
+<script setup>
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: companyTexts } = useTexts('company');
+
+</script>

--- a/resources/js/Pages/Contact/Hero.vue
+++ b/resources/js/Pages/Contact/Hero.vue
@@ -7,7 +7,7 @@
     >
 
       <h1 class="mt-4 text-black font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl mb-10">
-        Contact and Location
+        {{ contactTexts.title }}
       </h1>
       <div class="w-full h-auto">
         <img
@@ -18,31 +18,16 @@
       </div>
       <div class="w-full text-center md:text-left my-10 text-black flex flex-col md:flex-row">
         <div class="w-full md:w-1/3">
-            <h2 class="text-2xl font-semibold mb-2">Plant</h2>
-            <p class="text-lg">
-              Carretera Loma Alta 1418-A<br>
-              Col. Rural<br>
-              CP 25350 Arteaga, Coahuila, MX.<br>
-              Entrada por Libramiento Oscar<br>
-              Flores Tapia
-            </p>
+            <h2 class="text-2xl font-semibold mb-2">{{ contactTexts.address_title }}</h2>
+            <p class="text-lg" v-html="contactTexts.address_description"></p>
           </div>
           <div class="w-full md:w-1/3">
-            <h2 class="text-2xl font-semibold mb-2">Office Hours</h2>
-            <p class="text-lg">
-              Mon – Fri, 8:00am to 6:00pm<br>
-              Sat, 9:00am to 1:00pm
-            </p>
+            <h2 class="text-2xl font-semibold mb-2">{{ contactTexts.office_hours_title }}</h2>
+            <p class="text-lg" v-html="contactTexts.office_hours_description"></p>
           </div>
           <div class="w-full md:w-1/3">
-            <h2 class="text-2xl font-semibold mb-2">Phone</h2>
-            <p class="text-lg">(844) 135 0938</p>
-            <p class="text-lg">(844) 413 3137</p>
-            <br>
-            <p class="text-lg">Sales: Ext. 01</p>
-            <p class="text-lg">Invoicing: Ext. 02</p>
-            <p class="text-lg">Payments: Ext. 03</p>
-
+            <h2 class="text-2xl font-semibold mb-2">{{ contactTexts.phone_title }}</h2>
+            <p class="text-lg" v-html="contactTexts.phone_description"></p>
           </div>
       </div>
 
@@ -55,5 +40,8 @@
 
 <script setup>
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: contactTexts } = useTexts('contact');
 
 </script>

--- a/resources/js/Pages/Contact/Index.vue
+++ b/resources/js/Pages/Contact/Index.vue
@@ -2,12 +2,15 @@
 import { Head } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import Hero from '@/Pages/Contact/Hero.vue';
+import { useTexts } from '@/composables/useTexts';
 
 defineOptions({ layout: AppLayout });
+
+const { texts: contactTexts } = useTexts('contact');
 </script>
 
 <template>
-  <Head title="Contact" />
+  <Head :title="contactTexts.title || 'Contact'" />
 
   <!-- Location and contact information -->
   <Hero />

--- a/resources/js/Pages/Environment/Certifications.vue
+++ b/resources/js/Pages/Environment/Certifications.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="bg-gray-100 py-16">
     <div class="max-w-7xl mx-auto px-6">
-      <h2 class="text-4xl font-bold text-gray-900 mb-10">Certifications</h2>
+      <h2 class="text-4xl font-bold text-gray-900 mb-10">{{ environmentTexts.certifications_title }}</h2>
       <div class="w-full h-px bg-black my-6"></div>
       <p>Quality Management System –  ISO 9001:2015</p>
       <div class="w-full h-px bg-black my-6"></div>
@@ -9,3 +9,10 @@
     </div>
   </section>
 </template>
+
+<script setup>
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: environmentTexts } = useTexts('environment');
+
+</script>

--- a/resources/js/Pages/Environment/Hero.vue
+++ b/resources/js/Pages/Environment/Hero.vue
@@ -7,9 +7,7 @@
     >
 
       <h1 class="mt-4 text-black font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl mb-10">
-        Responsibility for the
-        <br class="hidden sm:block" />
-        Next Generation
+        {{ environmentTexts.hero_large }}
       </h1>
       <div class="w-full h-auto">
         <img
@@ -19,17 +17,7 @@
         />
       </div>
       <div class="w-full my-10 text-black text-2xl md:text-3xl font-light">
-        <p>
-          At Box Industries, sustainability isn't a trend — it's a commitment. 
-            We develop packaging solutions that reduce waste, optimize materials, and 
-            provide innovative technologies. From sourcing to development, we are 
-            constantly seeking better ways to minimize our environmental footprint while 
-            maintaining performance.
-        </p>
-        <p class="mt-6">
-        Because protecting what matters goes beyond packaging — it's about the 
-          future we help shape.
-        </p>
+        <p>{{ environmentTexts.hero_small }}</p>
       </div>
 
     </div>
@@ -40,7 +28,9 @@
 </template>
 
 <script setup>
-import { Link } from '@inertiajs/vue3';
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: environmentTexts } = useTexts('environment');
 
 </script>

--- a/resources/js/Pages/Environment/Index.vue
+++ b/resources/js/Pages/Environment/Index.vue
@@ -4,13 +4,16 @@ import Hero from '@/Pages/Environment/Hero.vue';
 import OurResponsibility from '@/Pages/Environment/OurResponsibility.vue';
 import Certifications from '@/Pages/Environment/Certifications.vue';
 import { Head } from '@inertiajs/vue3';
+import { useTexts } from '@/composables/useTexts';
 
 defineOptions({ layout: AppLayout });
+
+const { texts: environmentTexts } = useTexts('environment');
 
 </script>
 
 <template>
-  <Head title="Environment" />
+  <Head :title="environmentTexts.title || 'Environment'" />
   <Hero />
   <OurResponsibility />
   <Certifications />

--- a/resources/js/Pages/Environment/OurResponsibility.vue
+++ b/resources/js/Pages/Environment/OurResponsibility.vue
@@ -2,7 +2,7 @@
   <section class="bg-box-brown text-white py-24">
     <div class="max-w-7xl mx-auto px-6">
       <h2 class="text-4xl md:text-5xl font-bold text-yellow-400 mb-16">
-        Our responsibility
+        {{ environmentTexts.our_responsibility_title }}
       </h2>
 
       <div class="flex flex-col gap-16">
@@ -24,10 +24,10 @@
               {{ responsibility.title }}
             </h3>
             <h4 class="text-box-yellow">
-              {{ responsibility.short_description }}
+              {{ responsibility.subtitle }}
             </h4>
             <p class="text-white leading-relaxed">
-              {{ responsibility.long_description }}
+              {{ responsibility.description }}
             </p>
           </div>
         </div>
@@ -38,35 +38,36 @@
 </template>
 
 <script setup>
-const responsibilities = [
+import { computed } from 'vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: environmentTexts } = useTexts('environment');
+
+const responsibilities = computed(() => [
   {
-    title: 'Emissions',
+    title: environmentTexts.value?.responsibility_emissions_title,
+    subtitle: environmentTexts.value?.responsibility_emissions_subtitle,
+    description: environmentTexts.value?.responsibility_emissions_description,
     img_src: '/img/responsibility/BoxIndustries-Emissions.webp',
-    short_description: 'On the path to cleaner packaging operations',
-    long_description: "At Box Industries, we're taking concrete steps to reduce our environmental footprint. Our ongoing efforts include the reuse and recycling of plastic and corrugated pallets, minimizing waste across our logistics processes. As we expand, we're preparing a dedicated area within our facility for recycling used cardboard — moving toward a more circular packaging model.",
   },
-  
   {
-    title: 'Air Quality & Workspaces',
+    title: environmentTexts.value?.responsibility_air_quality_title,
+    subtitle: environmentTexts.value?.responsibility_air_quality_subtitle,
+    description: environmentTexts.value?.responsibility_air_quality_description,
     img_src: '/img/responsibility/BoxIndustries-AirQuality.webp',
-    short_description: 'Cleaner environments for better work and better impact',
-    long_description: "We are committed to maintaining clean, safe, and well-ventilated production areas. By optimizing airflow and filtering particulate matter during the handling of materials, we reduce airborne dust and improve workplace conditions — all while ensuring that our processes meet or exceed environmental standards.",
   },
-  
   {
-    title: 'Energy Use',
+    title: environmentTexts.value?.responsibility_energy_use_title,
+    subtitle: environmentTexts.value?.responsibility_energy_use_subtitle,
+    description: environmentTexts.value?.responsibility_energy_use_description,
     img_src: '/img/responsibility/BoxIndustries-EnergyUse.webp',
-    short_description: 'Advancing step by step toward cleaner energy',
-    long_description: "We are committed to maintaining clean, safe, and well-ventilated production areas. By optimizing airflow and filtering particulate matter during the handling of materials, we reduce airborne dust and improve workplace conditions — all while ensuring that our processes meet or exceed environmental standards.",
   },
-  
   {
-    title: 'Sustainable Products',
+    title: environmentTexts.value?.responsibility_sustainable_products_title,
+    subtitle: environmentTexts.value?.responsibility_sustainable_products_subtitle,
+    description: environmentTexts.value?.responsibility_sustainable_products_description,
     img_src: '/img/responsibility/BoxIndustries-SustainableProducts.webp',
-    short_description: 'Packaging with a second life',
-    long_description: "We believe packaging should do more than protect — it should protect responsibly. That's why we prioritize materials that are recyclable, reusable, and sourced responsibly. Our recycled pallet program is already active, and future developments will expand into cardboard recovery and repurposing — turning old packaging into new opportunities.",
   },
-  
-] 
+]);
 
 </script>

--- a/resources/js/Pages/Home/Hero.vue
+++ b/resources/js/Pages/Home/Hero.vue
@@ -13,20 +13,19 @@
     <div
       class="relative z-10 flex flex-col justify-center h-[calc(100%-7rem)] max-w-7xl mx-auto px-6"
     >
-      <p class="text-white text-2xl md:text-3xl font-light">Any Time, Any Size</p>
+      <p class="text-white text-2xl md:text-3xl font-light">{{ homeTexts.hero_small }}</p>
 
       <h1
         class="mt-4 text-white font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl"
       >
-        We think inside the box,<br class="hidden sm:block" />
-        so you don’t have to.
+        {{ homeTexts.hero_large }}
       </h1>
 
       <Link
-        href="/products"
+        :href="localizedPath('products')"
         class="mt-10 inline-block bg-box-yellow text-gray-900 font-semibold px-12 py-4 hover:bg-box-yellow/80 transition-colors duration-300 max-w-fit"
       >
-        Our Products
+        {{ homeTexts.products_button }}
       </Link>
     </div>
 
@@ -38,5 +37,10 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+import { useLocale } from '@/composables/useLocale';
+
+const { texts: homeTexts } = useTexts('home');
+const { localizedPath } = useLocale();
 
 </script>

--- a/resources/js/Pages/Home/Index.vue
+++ b/resources/js/Pages/Home/Index.vue
@@ -6,6 +6,7 @@ import PartnersAndCompany from '@/Pages/Home/PartnersAndCompany.vue';
 import ProductsCarousel from '@/Pages/Home/ProductsCarousel.vue';
 import NewGeneration from '@/Pages/Home/NewGeneration.vue';
 import LearnMore from '@/Pages/Home/LearnMore.vue';
+import { useTexts } from '@/composables/useTexts';
 
 // Props from backend
 const props = defineProps({
@@ -23,13 +24,15 @@ const props = defineProps({
 const page = usePage();
 const user = page.props.auth?.user;
 
+const { texts: homeTexts } = useTexts('home');
+
 // Tell Inertia to keep AppLayout instance alive between pages
 defineOptions({ layout: AppLayout });
 
 </script>
 
 <template>
-  <Head title="Home" />
+  <Head :title="homeTexts.title || 'Home'" />
   <Hero />
   <PartnersAndCompany />
   <ProductsCarousel />

--- a/resources/js/Pages/Home/LearnMore.vue
+++ b/resources/js/Pages/Home/LearnMore.vue
@@ -4,7 +4,7 @@
     <div class="max-w-6xl mx-auto px-4">
       <!-- Intro text -->
       <p class="text-2xl md:text-3xl leading-tight font-medium mb-8">
-        Box Industries offers its clients end-to-end expertise — from design and material sourcing to project management and scalable production. Discover more about our process here.
+        {{ homeTexts.about_us_section_text }}
       </p>
 
       <!-- Call-to-action button -->
@@ -12,7 +12,7 @@
         type="button"
         class="bg-box-brown text-box-yellow-light px-6 py-3 shadow hover:bg-box-brown/90 transition-colors"
       >
-        Learn More
+        {{ homeTexts.about_us_section_button }}
       </button>
 
       <!-- Image -->
@@ -26,3 +26,10 @@
     </div>
   </section>
 </template>
+
+<script setup>
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: homeTexts } = useTexts('home');
+
+</script>

--- a/resources/js/Pages/Home/NewGeneration.vue
+++ b/resources/js/Pages/Home/NewGeneration.vue
@@ -3,7 +3,7 @@
   <section class="bg-box-brown text-white py-12">
     <div class="max-w-6xl mx-auto px-4">
       <h4 class="text-box-yellow-light text-5xl mb-8">
-        Ready for the new generation
+        {{ homeTexts.new_generation_section_title }}
       </h4>
     </div>
     <div class="flex flex-col max-w-6xl mx-auto px-4">
@@ -36,11 +36,13 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { ref } from 'vue'
 import { NewGenSlides as slides } from '@/Pages/Home/data/NewGenSlides'
 import SlideChanger from '@/Components/SlideChanger.vue'
+import { useTexts } from '@/composables/useTexts';
 
 const currentIndex = ref(0)
+const { texts: homeTexts } = useTexts('home');
 
 const next = () => {
   currentIndex.value = (currentIndex.value + 1) % slides.length

--- a/resources/js/Pages/Home/PartnersAndCompany.vue
+++ b/resources/js/Pages/Home/PartnersAndCompany.vue
@@ -1,21 +1,19 @@
 <script setup>
 import Partners from '@/Components/Containers/Partners.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: homeTexts } = useTexts('home');
 
 </script>
 
 <template>
   <section class="bg-gray-100 py-4 text-black">
     <div class="px-4 mx-auto max-w-7xl">
-      <h4>Trust in Us</h4>
+      <h4>{{ homeTexts.partners_section_title }}</h4>
 
       <Partners />
-      <h4 class="mt-10">Company</h4>
-      <p class="text-3xl mt-4">
-        Box Industries is a leading Mexican provider of innovative, high-quality
-        packaging solutions. We help our clients develop packaging systems that
-        are ready to meet the future demands of sustainability, efficiency, and
-        performance.
-      </p>
+      <h4 class="mt-10">{{ homeTexts.company_section_title }}</h4>
+      <p class="text-3xl mt-4">{{ homeTexts.company_section_description }}</p>
     </div>
   </section>
 </template>

--- a/resources/js/Pages/Products/Hero.vue
+++ b/resources/js/Pages/Products/Hero.vue
@@ -14,13 +14,10 @@
       <h1
         class="mt-4 text-white font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl"
       >
-      Packaging that 
-      <br class="hidden sm:block" />
-      fits your world
+      {{ productsTexts.hero_large }}
       </h1>
       <p class="mt-8 text-white text-2xl md:text-3xl font-light">
-        Together, we create packaging that's <br class="hidden sm:block" />
-        ready for whatever the future holds.
+        {{ productsTexts.hero_small }}
       </p>
 
     </div>
@@ -31,7 +28,9 @@
 </template>
 
 <script setup>
-import { Link } from '@inertiajs/vue3';
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: productsTexts } = useTexts('products');
 
 </script>

--- a/resources/js/Pages/Public/Products/Index.vue
+++ b/resources/js/Pages/Public/Products/Index.vue
@@ -3,9 +3,12 @@ import { Head, Link, usePage } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import Hero from '@/Pages/Products/Hero.vue';
 import ProductGrid from '@/Pages/Products/ProductGrid.vue';
+import { useTexts } from '@/composables/useTexts';
 
 // Optional: see if a user is logged-in to show admin links
 const page = usePage();
+
+const { texts: productsTexts } = useTexts('products');
 
 // Tell Inertia to keep AppLayout instance alive between pages
 defineOptions({ layout: AppLayout });
@@ -13,11 +16,11 @@ defineOptions({ layout: AppLayout });
 </script>
 
 <template>
-  <Head title="Products" />
+  <Head :title="productsTexts.title || 'Products'" />
   <Hero />
   <div class="bg-gray-100 py-10">
     <div class="max-w-7xl mx-auto px-6">
-      <h2 class="text-4xl font-bold text-black">Our product portfolio</h2>
+      <h2 class="text-4xl font-bold text-black">{{ productsTexts.products_section_title }}</h2>
     </div>
   </div>
   <ProductGrid 

--- a/resources/js/Pages/Public/Services/Hero_Figma.vue
+++ b/resources/js/Pages/Public/Services/Hero_Figma.vue
@@ -7,9 +7,7 @@
     >
 
       <h1 class="mt-4 text-black font-extrabold leading-tight text-5xl sm:text-6xl md:text-7xl lg:text-8xl mb-10">
-        Overview of 
-        <br class="hidden sm:block" />
-        Our Services
+        {{ servicesTexts.hero_large }}
       </h1>
       <div class="w-full h-auto">
         <img
@@ -19,12 +17,7 @@
         />
       </div>
       <div class="w-full my-10 text-black text-2xl md:text-3xl font-light">
-        <p>
-          Box Industries supports its clients from concept to scalable production. 
-        </p>
-        <p>
-          Discover our full range of packaging solutions here.
-        </p>
+        <p>{{ servicesTexts.hero_small }}</p>
       </div>
 
     </div>
@@ -35,7 +28,9 @@
 </template>
 
 <script setup>
-import { Link } from '@inertiajs/vue3';
 import WhatsappButton from '@/Components/Buttons/WhatsappButton.vue';
+import { useTexts } from '@/composables/useTexts';
+
+const { texts: servicesTexts } = useTexts('services');
 
 </script>

--- a/resources/js/Pages/Public/Services/Index.vue
+++ b/resources/js/Pages/Public/Services/Index.vue
@@ -4,17 +4,20 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import Hero from '@/Pages/Public/Services/Hero_Figma.vue';
 import ServicesList from '@/Pages/Public/Services/ServicesList.vue';
 import { Services } from '@/data';
+import { useTexts } from '@/composables/useTexts';
 
 defineOptions({ layout: AppLayout });
+
+const { texts: servicesTexts } = useTexts('services');
 
 </script>
 
 <template>
-    <Head title="Services" />
+    <Head :title="servicesTexts.title || 'Services'" />
     <Hero />
     <section class="w-full bg-box-brown py-12 mx-auto sm:px-6 lg:px-8">
         <div class="w-full max-w-7xl px-6 mx-auto">
-            <h1 class="text-5xl font-bold mb-6 text-box-yellow">Development</h1>
+            <h1 class="text-5xl font-bold mb-6 text-box-yellow">{{ servicesTexts.services_section_title }}</h1>
         </div>
         <ServicesList :services="Services" />
     </section>

--- a/resources/js/composables/useLocale.ts
+++ b/resources/js/composables/useLocale.ts
@@ -1,0 +1,42 @@
+import { computed } from 'vue';
+import { usePage } from '@inertiajs/vue3';
+
+const SUPPORTED_LANGS = ['en', 'es'] as const;
+
+type SupportedLang = typeof SUPPORTED_LANGS[number];
+
+function normalizePath(path: string) {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return normalized === '/' ? '' : normalized;
+}
+
+export function useLocale() {
+  const page = usePage();
+  const lang = computed<SupportedLang>(() => {
+    const value = page.props.lang as string | undefined;
+    return (SUPPORTED_LANGS.find((supported) => supported === value) ?? 'en') as SupportedLang;
+  });
+
+  const localizedPath = (path = ''): string => {
+    if (!path) {
+      return `/${lang.value}`;
+    }
+
+    return `/${lang.value}${normalizePath(path)}`;
+  };
+
+  const pathForLanguage = (targetLang: SupportedLang): string => {
+    const [path, query] = page.url.split('?');
+    const strippedPath = path.replace(/^\/(en|es)/, '');
+    const querySuffix = query ? `?${query}` : '';
+
+    return `/${targetLang}${strippedPath || ''}${querySuffix}`;
+  };
+
+  return {
+    lang,
+    localizedPath,
+    pathForLanguage,
+  };
+}
+

--- a/resources/js/composables/useTexts.ts
+++ b/resources/js/composables/useTexts.ts
@@ -1,0 +1,37 @@
+import { computed, ref, watchEffect } from 'vue';
+import { usePage } from '@inertiajs/vue3';
+
+type LanguageTexts = Record<string, Record<string, string>>;
+
+let textsModulePromise: Promise<typeof import('@/data/TextsByLang')> | null = null;
+
+async function loadTextsModule() {
+  if (!textsModulePromise) {
+    textsModulePromise = import('@/data/TextsByLang');
+  }
+
+  return textsModulePromise;
+}
+
+export function useTexts(sectionKey: string) {
+  const page = usePage();
+  const lang = computed(() => (page.props.lang as string | undefined) ?? 'en');
+  const sectionTexts = ref<Record<string, string>>({});
+
+  watchEffect(() => {
+    const currentLang = lang.value;
+
+    loadTextsModule().then(({ Texts }) => {
+      const allTexts = Texts as unknown as LanguageTexts;
+      const fallbackLanguage = allTexts['en'] ?? {};
+      const languageTexts = allTexts[currentLang] ?? fallbackLanguage;
+      sectionTexts.value = languageTexts[sectionKey] ?? fallbackLanguage[sectionKey] ?? {};
+    });
+  });
+
+  return {
+    lang,
+    texts: computed(() => sectionTexts.value),
+  };
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,52 +10,61 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::get('/', function () {
-    return Inertia::render('Home/Index', [
-        'menu_style' => 'wood',
-        'footer_style' => 'dark',
-        'canLogin' => Route::has('login'),
-        'carouselProducts' => Product::where('on_carrousel', true)->get(),
-        'products' => Product::all(),
-        'partners' => Partner::orderBy('sort_order')->get(),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
+Route::redirect('/', '/en');
+
+Route::pattern('lang', 'en|es');
+
+Route::group([
+    'prefix' => '{lang}',
+    'where' => ['lang' => 'en|es'],
+], function () {
+    Route::get('/', function (string $lang) {
+        return Inertia::render('Home/Index', [
+            'menu_style' => 'wood',
+            'footer_style' => 'dark',
+            'canLogin' => Route::has('login'),
+            'carouselProducts' => Product::where('on_carrousel', true)->get(),
+            'products' => Product::all(),
+            'partners' => Partner::orderBy('sort_order')->get(),
+            'canRegister' => Route::has('register'),
+            'laravelVersion' => Application::VERSION,
+            'phpVersion' => PHP_VERSION,
+            'lang' => $lang,
+        ]);
+    })->name('home');
+
+    // Subpages in menu order
+    Route::get('/products', [ProductController::class, 'publicIndex'])->name('products.public.index');
+
+    Route::get('/services', [ServiceController::class, 'publicIndex'])->name('services.public.index');
+
+    Route::get('/company', function (string $lang) {
+        return Inertia::render('Company/Index', [
+            'menu_style' => 'black',
+            'footer_style' => 'dark',
+            'partners' => Partner::orderBy('sort_order')->get(),
+            'lang' => $lang,
+        ]);
+    })->name('company.index');
+
+    Route::get('/environment', function (string $lang) {
+        return Inertia::render('Environment/Index', [
+            'menu_style' => 'black',
+            'footer_style' => 'dark',
+            'lang' => $lang,
+        ]);
+    })->name('environment.index');
+
+    Route::get('/contact', function (string $lang) {
+        return Inertia::render('Contact/Index', [
+            'menu_style' => 'black',
+            'footer_style' => 'light',
+            'lang' => $lang,
+        ]);
+    })->name('contact.index');
+
+    Route::get('/partners', [PartnerController::class, 'publicIndex'])->name('partners.public.index');
 });
-
-// Subpages in menu order
-Route::get('/products', [ProductController::class, 'publicIndex'])->name('products.public.index');
-
-Route::get('/services', [ServiceController::class, 'publicIndex'])->name('services.public.index');
-
-Route::get('/company', function () {
-    return Inertia::render('Company/Index', [
-        'menu_style' => 'black',
-        'footer_style' => 'dark',
-        'partners' => Partner::orderBy('sort_order')->get(),
-    ]);
-})->name('company.index');
-
-Route::get('/environment', function () {
-    return Inertia::render('Environment/Index', [
-        'menu_style' => 'black',
-        'footer_style' => 'dark',
-    ]);
-})->name('environment.index');
-
-Route::get('/contact', function () {
-    return Inertia::render('Contact/Index', [
-        'menu_style' => 'black',
-        'footer_style' => 'light',
-    ]);
-})->name('contact.index');
-
-
-
-Route::get(
-        '/partners', [PartnerController::class, 'publicIndex']
-    )->name('partners.public.index');
 
 Route::get('/admin/dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- group public web routes under a language prefix and propagate the locale to Inertia responses
- add locale/text composables and update the shared layout, footer, and pages to load copy from `TextsByLang`
- refresh page copy, navigation, and CTA links so content and URLs switch based on the active language

## Testing
- npm run build *(fails: Could not resolve ../../vendor/tightenco/ziggy)*

------
https://chatgpt.com/codex/tasks/task_e_68e4892e5fac8320ab5e22c8bfa1e356